### PR TITLE
Fixed CloseShieldOutputStream being prematurely closed

### DIFF
--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/ModelSerializer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/ModelSerializer.java
@@ -189,7 +189,7 @@ public class ModelSerializer {
             // now, add our normalizer as additional entry
             ZipEntry nEntry = new ZipEntry(NORMALIZER_BIN);
             zipfile.putNextEntry(nEntry);
-            NormalizerSerializer.getDefault().write(dataNormalization, zipfile);
+            NormalizerSerializer.getDefault().write(dataNormalization, CloseShieldOutputStream.wrap(zipfile));
         }
 
         dos.close();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Wrapped a CloseShieldOutputStream around the ZipOutputStream in ModelSerializer#writeModel before it is passed into NormalizerSerializer#write.
NormalizerSerializer#write closes the stream it receives which in this case is a ZipOutputStream wrapping a CloseShieldStream. This causes an IOException because the ZipOutputStream is closed again in ModelSerializer#writeModel and closing the stream again calls the flush method which ends up attempting to flush the ClosedOutputStream in the now closed CloseShieldOutputStream.

## How was this patch tested?

Added a new test to check for this issue. Test has not been run.

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.konduit.ai/multi-project/how-to-guides/contribute/eclipse-contributors) page for details
- [x] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [x] Created tests for any significant new code additions.
- [ ] Relevant tests for your changes are passing.
